### PR TITLE
Idam 2788 fix plan

### DIFF
--- a/terraform-template/state.config
+++ b/terraform-template/state.config
@@ -1,4 +1,19 @@
+// Please only use the block for the tenant you are deploying to. Please delete the blocks for the tenants you are NOT deploying to.
+
+// Devl Config
 resource_group_name = "rg-eucs-idam-observability"
 storage_account_name= "stidamobservetfstate"
 container_name      = "tfstate-env"
 key                 = "staff-identity-idam-entra-infra-DEPARTMENT_NAME-TEAM_NAME-devl.tfstate"
+
+// Nle Config
+resource_group_name = "rg-eucs-idam-observability"
+storage_account_name= "steucsidamentratfnle"
+container_name      = "tfstate"
+key                 = "staff-identity-idam-entra-infra-DEPARTMENT_NAME-TEAM_NAME-nle.tfstate"
+
+// Live Config
+resource_group_name = "rg-eucs-idam-observability"
+storage_account_name= "steucsidamentratf"
+container_name      = "tfstate"
+key                 = "staff-identity-idam-entra-infra-DEPARTMENT_NAME-TEAM_NAME-live.tfstate"

--- a/terraform/envs/live/ims-cfhands/state.config
+++ b/terraform/envs/live/ims-cfhands/state.config
@@ -1,4 +1,4 @@
 resource_group_name = "rg-eucs-idam-observability"
-storage_account_name= "stidamobservetfstate"
-container_name      = "tfstate-env"
+storage_account_name= "steucsidamentratf"
+container_name      = "tfstate"
 key                 = "staff-identity-idam-entra-infra-cfhands-live.tfstate"


### PR DESCRIPTION
## 🚀 Pull Request Summary

**Title:**  
Fix failed plan in live

**Description:**  
Fixes failed plan in live and updates the terraform template

**Fixes:** [IDAM-2788](https://dsdmoj.atlassian.net/browse/IDAM-2788)

## 🔐 Identity & Access Management (Azure)

### The below boxes are general guidance and points to consider. Only the relevant box's require ticking, relevant to the changes you are implementing.  

- [ ] Have all Azure resources been assigned **least privilege** access?
- [ ] Are **Managed Identities** used instead of hardcoded credentials or secrets?
- [ ] Are **Azure RBAC roles** scoped appropriately (e.g., resource group vs. subscription)?
- [ ] Have **role assignments** been reviewed for over-permissioning?
- [ ] Are **Azure AD groups** used for access control where applicable?
- [ ] Are **Key Vaults** used for storing secrets, certificates, or keys?
- [ ] Have **access policies** or **RBAC roles** for Key Vaults been reviewed?

## 🧪 Testing & Validation

- [ ] Have changes been tested in a **non-production** environment?
- [ ] Are there **unit/integration tests** for IAM logic or automation scripts?

## 📄 Documentation

- [ ] Is there documentation for new IAM roles, policies, or automation logic ect?
- [ ] Have runbooks or operational guides been updated?

## 📎 Related Issues / Tickets

_Reference any related issues, JIRA tickets, or documentation._

## ✅ Checklist

- [x] I have reviewed the code and confirm it meets the project’s IAM, security and automation standards.
- [x] I have verified that no sensitive data is exposed in logs or code.
- [x] I have updated relevant documentation and diagrams.
- [x] I have reviewed my own code and the plan

---

🛡️ **Security is everyone's responsibility. Please ensure all IAM changes are reviewed carefully.**

## ✅ Reviewer Checklist
- [ ] I have reviewed the code and confirm it meets the project’s IAM, security and automation standards.
- [ ] I have verified that no sensitive data is exposed in logs or code.
