### PR TITLE
Change LASSIE/SILAS redirects to Test for NLE

### DIFF
--- a/terraform/envs/nleexternal/laa/variables.tf
+++ b/terraform/envs/nleexternal/laa/variables.tf
@@ -80,7 +80,7 @@ variable "applications" {
       allowed_groups                 = ["APPREG-User-Access-LAAD-LASSIE","DEPT-All-Legal-Aid-Agency-Internal-Staff"]
       homepage_url                   = null
       logout_url                     = null
-      redirect_uris                  = ["https://laa-landing-page-dev.apps.live.cloud-platform.service.justice.gov.uk/login/oauth2/code/azure"]
+      redirect_uris                  = ["https://laa-landing-page-test.apps.live.cloud-platform.service.justice.gov.uk/login/oauth2/code/azure"]
       mobile_desktop_redirect_uris   = null
       app_roles                      = []
       graph_application_permissions  = ["CustomAuthenticationExtension.Receive.Payload","User.Invite.All","Directory.Read.All","User.Read.All","GroupMember.ReadWrite.All","AuditLog.Read.All","Application.Read.All"]
@@ -96,7 +96,7 @@ variable "applications" {
         application_template_name     = null
         hide                          = true
       }
-      identifier_uris = ["api://laa-landing-page-dev.apps.live.cloud-platform.service.justice.gov.uk/77595545-15fc-4d83-89d4-3e36387dafa9"]
+      identifier_uris = ["api://laa-landing-page-test.apps.live.cloud-platform.service.justice.gov.uk/77595545-15fc-4d83-89d4-3e36387dafa9"]
       api = {
         known_client_applications      = []
         mapped_claims_enabled          = false
@@ -341,7 +341,7 @@ variable "applications" {
         application_template_name     = null
         hide                          = true
       }
-      identifier_uris = ["api://laa-landing-page-dev.apps.live.cloud-platform.service.justice.gov.uk/a9faa077-878c-48df-a735-e96ffc694ac5"]
+      identifier_uris = ["api://laa-landing-page-test.apps.live.cloud-platform.service.justice.gov.uk/a9faa077-878c-48df-a735-e96ffc694ac5"]
       api                              = {
         known_client_applications      = null,
         mapped_claims_enabled          = null,


### PR DESCRIPTION
## 🚀 Pull Request Summary

**Title:**  
Change LASSIE/SILAS redirects to point at our Test/NLE environment end points

**Description:**  
I've changed the Dev endpoints to the Test/NLE endpoints for both LASSIE/SILAS app registrations - I also validated all the UIDs are correct and pointing at the correct objects.

**Fixes:** N/A

## 🔐 Identity & Access Management (Azure)

### The below boxes are general guidance and points to consider. Only the relevant box's require ticking, relevant to the changes you are implementing.  

- [ ] Have all Azure resources been assigned **least privilege** access?
- [ ] Are **Managed Identities** used instead of hardcoded credentials or secrets?
- [ ] Are **Azure RBAC roles** scoped appropriately (e.g., resource group vs. subscription)?
- [ ] Have **role assignments** been reviewed for over-permissioning?
- [ ] Are **Azure AD groups** used for access control where applicable?
- [ ] Are **Key Vaults** used for storing secrets, certificates, or keys?
- [ ] Have **access policies** or **RBAC roles** for Key Vaults been reviewed?

## 🧪 Testing & Validation

- [ ] Have changes been tested in a **non-production** environment?
- [ ] Are there **unit/integration tests** for IAM logic or automation scripts?

## 📄 Documentation

- [ ] Is there documentation for new IAM roles, policies, or automation logic ect?
- [ ] Have runbooks or operational guides been updated?

## 📎 Related Issues / Tickets

_Reference any related issues, JIRA tickets, or documentation._

## ✅ Checklist

- [x] I have reviewed the code and confirm it meets the project’s IAM, security and automation standards.
- [x] I have verified that no sensitive data is exposed in logs or code.
- [x] I have updated relevant documentation and diagrams.
- [x] I have reviewed my own code and the plan

---

🛡️ **Security is everyone's responsibility. Please ensure all IAM changes are reviewed carefully.**

## ✅ Reviewer Checklist
- [ ] I have reviewed the code and confirm it meets the project’s IAM, security and automation standards.
- [ ] I have verified that no sensitive data is exposed in logs or code.
