### PR TITLE
Add kv

### DIFF
--- a/terraform/envs/live/idam-internal/main.tf
+++ b/terraform/envs/live/idam-internal/main.tf
@@ -5,3 +5,32 @@ locals {
     source     = "terraform"
   }
 }
+
+resource "azurerm_key_vault" "idam-internal_vault" {
+  name                        = "kv-internal-idam-live"
+  location                    = data.azurerm_resource_group.internal-rg.location
+  resource_group_name         = data.azurerm_resource_group.internal-rg.name
+  enabled_for_disk_encryption = true
+  tenant_id                   = data.azurerm_client_config.current.tenant_id
+  soft_delete_retention_days  = 7
+  purge_protection_enabled    = false
+
+  sku_name = "standard"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Get",
+    ]
+
+    secret_permissions = [
+      "Get",
+    ]
+
+    storage_permissions = [
+      "Get",
+    ]
+  }
+}

--- a/terraform/envs/nle/idam-internal/main.tf
+++ b/terraform/envs/nle/idam-internal/main.tf
@@ -5,3 +5,32 @@ locals {
     source     = "terraform"
   }
 }
+
+resource "azurerm_key_vault" "idam-internal_vault" {
+  name                        = "kv-internal-idam-nle"
+  location                    = data.azurerm_resource_group.internal-rg.location
+  resource_group_name         = data.azurerm_resource_group.internal-rg.name
+  enabled_for_disk_encryption = true
+  tenant_id                   = data.azurerm_client_config.current.tenant_id
+  soft_delete_retention_days  = 7
+  purge_protection_enabled    = false
+
+  sku_name = "standard"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Get",
+    ]
+
+    secret_permissions = [
+      "Get",
+    ]
+
+    storage_permissions = [
+      "Get",
+    ]
+  }
+}


### PR DESCRIPTION
## 🚀 Pull Request Summary

**Title:**  
Add idam-internal kv to nle and live

**Description:**  
Add idam-internal kv to nle and live

**Fixes:** [IDAM-4019](https://dsdmoj.atlassian.net/browse/IDAM-4019)

## 🔐 Identity & Access Management (Azure)

### The below boxes are general guidance and points to consider. Only the relevant box's require ticking, relevant to the changes you are implementing.  

- [ ] Have all Azure resources been assigned **least privilege** access?
- [ ] Are **Managed Identities** used instead of hardcoded credentials or secrets?
- [ ] Are **Azure RBAC roles** scoped appropriately (e.g., resource group vs. subscription)?
- [ ] Have **role assignments** been reviewed for over-permissioning?
- [ ] Are **Azure AD groups** used for access control where applicable?
- [ ] Are **Key Vaults** used for storing secrets, certificates, or keys?
- [ ] Have **access policies** or **RBAC roles** for Key Vaults been reviewed?

## 🧪 Testing & Validation

- [ ] Have changes been tested in a **non-production** environment?
- [ ] Are there **unit/integration tests** for IAM logic or automation scripts?

## 📄 Documentation

- [ ] Is there documentation for new IAM roles, policies, or automation logic ect?
- [ ] Have runbooks or operational guides been updated?

## 📎 Related Issues / Tickets

_Reference any related issues, JIRA tickets, or documentation._

## ✅ Checklist

- [ ] I have reviewed the code and confirm it meets the project’s IAM, security and automation standards.
- [ ] I have verified that no sensitive data is exposed in logs or code.
- [ ] I have updated relevant documentation and diagrams.
- [ ] I have reviewed my own code and the plan

---

🛡️ **Security is everyone's responsibility. Please ensure all IAM changes are reviewed carefully.**

## ✅ Reviewer Checklist
- [ ] I have reviewed the code and confirm it meets the project’s IAM, security and automation standards.
- [ ] I have verified that no sensitive data is exposed in logs or code.
