### PR TITLE
Add access policy

### DIFF
--- a/terraform/envs/live/idam-internal/main.tf
+++ b/terraform/envs/live/idam-internal/main.tf
@@ -34,3 +34,19 @@ resource "azurerm_key_vault" "idam-internal_vault" {
     ]
   }
 }
+
+resource "azurerm_key_vault_access_policy" "example" {
+  for_each = var.engineer_object_ids
+
+  key_vault_id = azurerm_key_vault.idam-internal_vault.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = each.value
+
+  key_permissions = [
+    "Get",
+  ]
+
+  secret_permissions = [
+    "Get",
+  ]
+}

--- a/terraform/envs/live/idam-internal/variables.tf
+++ b/terraform/envs/live/idam-internal/variables.tf
@@ -3,3 +3,18 @@ variable "location" {
   type        = string
   default     = "uksouth"
 }
+
+variable "engineer_object_ids" {
+  type = map(string)
+  default = {
+    "jason"   = "d1ed6381-bd89-4d61-a1f5-95ccc3d61366"
+    "luciano" = "d904ed25-013f-4865-90d4-768705fa4b55"
+    "mike"    = "9d7b8242-c676-4bbc-b1e9-8d80e5d0c695"
+    "abarna"  = "b047df82-70b5-413b-9a9a-6c124069d525"
+    "matt"    = "dea4036e-fe8b-448a-aad9-f62f68aa5d6d"
+    "davidH"  = "c41bb844-1b70-4054-90a4-022f4394adcd"
+    "davidS"  = "edbbf78a-743a-4882-b936-44db72748efd"
+    "lee"     = "18b2af17-0361-436d-a908-15fc731eef8f"
+    "john"    = "13c1e9d4-6f71-4015-b8b8-fa20ca4545d8"
+  }
+}

--- a/terraform/envs/nle/idam-internal/main.tf
+++ b/terraform/envs/nle/idam-internal/main.tf
@@ -34,3 +34,19 @@ resource "azurerm_key_vault" "idam-internal_vault" {
     ]
   }
 }
+
+resource "azurerm_key_vault_access_policy" "example" {
+  for_each = var.engineer_object_ids
+
+  key_vault_id = azurerm_key_vault.idam-internal_vault.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = each.value
+
+  key_permissions = [
+    "Get",
+  ]
+
+  secret_permissions = [
+    "Get",
+  ]
+}

--- a/terraform/envs/nle/idam-internal/variables.tf
+++ b/terraform/envs/nle/idam-internal/variables.tf
@@ -3,3 +3,18 @@ variable "location" {
   type        = string
   default     = "uksouth"
 }
+
+variable "engineer_object_ids" {
+  type = map(string)
+  default = {
+    "jason"   = "369d87ee-ed68-4cf3-8306-a711dd296d5f"
+    "luciano" = "0beaf9d2-60d5-44f2-8f20-78ef6cd0341b"
+    "mike"    = "d17c5b94-d6b9-4425-bdaa-08a86c9bb9da"
+    "abarna"  = "16da44e7-3e25-4cf5-8d6f-2eab69859963"
+    "matt"    = "a4c5e28a-4c3b-4600-b827-33ffec9a9121"
+    "davidH"  = "ce142434-27d0-4112-89f5-4e768879abde"
+    "davidS"  = "1ae3de89-d85f-4fb1-b1d9-36d9c641bf7d"
+    "lee"     = "012ccc81-bbfa-4e94-8058-c30e6cfc5643"
+    "john"    = "38cc9777-479f-450f-acf8-f8856ba861ba"
+  }
+}


### PR DESCRIPTION
## 🚀 Pull Request Summary

**Title:**  
Add access policy

**Description:**  
Add access policy to nle and live for the internal idam KV

**Fixes:** [IDAM-4019](https://dsdmoj.atlassian.net/browse/IDAM-4019)

## 🔐 Identity & Access Management (Azure)

### The below boxes are general guidance and points to consider. Only the relevant box's require ticking, relevant to the changes you are implementing.  

- [ ] Have all Azure resources been assigned **least privilege** access?
- [ ] Are **Managed Identities** used instead of hardcoded credentials or secrets?
- [ ] Are **Azure RBAC roles** scoped appropriately (e.g., resource group vs. subscription)?
- [ ] Have **role assignments** been reviewed for over-permissioning?
- [ ] Are **Azure AD groups** used for access control where applicable?
- [ ] Are **Key Vaults** used for storing secrets, certificates, or keys?
- [ ] Have **access policies** or **RBAC roles** for Key Vaults been reviewed?

## 🧪 Testing & Validation

- [ ] Have changes been tested in a **non-production** environment?
- [ ] Are there **unit/integration tests** for IAM logic or automation scripts?

## 📄 Documentation

- [ ] Is there documentation for new IAM roles, policies, or automation logic ect?
- [ ] Have runbooks or operational guides been updated?

## 📎 Related Issues / Tickets

_Reference any related issues, JIRA tickets, or documentation._

## ✅ Checklist

- [ ] I have reviewed the code and confirm it meets the project’s IAM, security and automation standards.
- [ ] I have verified that no sensitive data is exposed in logs or code.
- [ ] I have updated relevant documentation and diagrams.
- [ ] I have reviewed my own code and the plan

---

🛡️ **Security is everyone's responsibility. Please ensure all IAM changes are reviewed carefully.**

## ✅ Reviewer Checklist
- [ ] I have reviewed the code and confirm it meets the project’s IAM, security and automation standards.
- [ ] I have verified that no sensitive data is exposed in logs or code.
