### PR TITLE
add missing VDS TF SP

### DIFF
--- a/terraform/envs/devl/eucs-vds/variables.tf
+++ b/terraform/envs/devl/eucs-vds/variables.tf
@@ -198,6 +198,36 @@ variable "applications" {
         hide                          = null
       }
       identifier_uris = null
+    },
+    "vds_subscription_automation_05" = {
+      notes                          = "Used for Terraform automation activities in VDS subscriptions"
+      service_management_reference   = "EUCSVDS-1512"
+      display_name                   = "MoJ-OFFICIAL-Devl-Spoke-EUCS-TF"
+      department_name                = "EUCS-CORE-AVD"
+      team_name                      = "EUCS-CORE-Infrastructure-AVD"
+      application_name               = "MoJ-OFFICIAL-Devl-Spoke-EUCS-TF"
+      create_access_package          = false
+      access_package_reviewers       = []
+      owners                         = ["dclose-admin@devl.justice.gov.uk", "dletic-admin@devl.justice.gov.uk", "ihegarty-admin@devl.justice.gov.uk", "mkirkpatrick-admin@devl.justice.gov.uk", "pcolegate-admin@devl.justice.gov.uk"]
+      allowed_groups                 = []
+      homepage_url                   = null
+      logout_url                     = null
+      redirect_uris                  = null
+      app_roles                      = []
+      graph_application_permissions  = ["Directory.Read.All", "User.Read.All", "Group.Create", "Group.ReadWrite.All"]
+      graph_delegated_permissions    = []
+      tenants_required               = ["DEVL"]
+      federated_identity_credentials = []
+      service_principle = {
+        login_url                     = null
+        notification_email_addresses  = []
+        preferred_single_sign_on_mode = null
+        app_role_assignment_required  = true
+        account_enabled               = true
+        application_template_name     = null
+        hide                          = null
+      }
+      identifier_uris = null
     }
   }
 }

--- a/terraform/envs/live/eucs-vds/variables.tf
+++ b/terraform/envs/live/eucs-vds/variables.tf
@@ -228,6 +228,36 @@ variable "applications" {
         hide                          = null
       }
       identifier_uris = null
+    },
+    "vds_subscription_automation_05" = {
+      notes                          = "Used for Terraform automation activities in VDS subscriptions"
+      service_management_reference   = "EUCSVDS-1512"
+      display_name                   = "MoJ-OFFICIAL-Prod-Spoke-EUCS-TF"
+      department_name                = "EUCS-CORE-AVD"
+      team_name                      = "EUCS-CORE-Infrastructure-AVD"
+      application_name               = "MoJ-OFFICIAL-Prod-Spoke-EUCS-TF"
+      create_access_package          = false
+      access_package_reviewers       = []
+      owners                         = ["David.Close@JusticeUK.onmicrosoft.com", "Dragan.letic1@JusticeUK.onmicrosoft.com", "Ian.Hegarty@JusticeUK.onmicrosoft.com", "Michael.Kirkpatrick@JusticeUK.onmicrosoft.com", "Paul.Colegate@JusticeUK.onmicrosoft.com"]
+      allowed_groups                 = []
+      homepage_url                   = null
+      logout_url                     = null
+      redirect_uris                  = null
+      app_roles                      = []
+      graph_application_permissions  = ["Directory.Read.All", "User.Read.All", "Group.Create", "Group.ReadWrite.All"]
+      graph_delegated_permissions    = []
+      tenants_required               = ["LIVE"]
+      federated_identity_credentials = []
+      service_principle = {
+        login_url                     = null
+        notification_email_addresses  = []
+        preferred_single_sign_on_mode = null
+        app_role_assignment_required  = true
+        account_enabled               = true
+        application_template_name     = null
+        hide                          = null
+      }
+      identifier_uris = null
     }
   }
 }


### PR DESCRIPTION
## 🚀 Pull Request Summary

**Title:**  
_New Terraform Service Principal for VDS use._

**Description:**  
<!--
"Add new Terraform service principal for VDS use, was missing from subscription"
-->

**Fixes:** [Jira-1512](https://dsdmoj.atlassian.net/browse/EUCSVDS-1512)

## 🔐 Identity & Access Management (Azure)

### The below boxes are general guidance and points to consider. Only the relevant box's require ticking, relevant to the changes you are implementing.  

- [x] Have all Azure resources been assigned **least privilege** access?
- [ ] Are **Managed Identities** used instead of hardcoded credentials or secrets?
- [x] Are **Azure RBAC roles** scoped appropriately (e.g., resource group vs. subscription)?
- [x] Have **role assignments** been reviewed for over-permissioning?
- [ ] Are **Azure AD groups** used for access control where applicable?
- [x] Are **Key Vaults** used for storing secrets, certificates, or keys?
- [x] Have **access policies** or **RBAC roles** for Key Vaults been reviewed?

## 🧪 Testing & Validation

- [x] Have changes been tested in a **non-production** environment?
- [x] Are there **unit/integration tests** for IAM logic or automation scripts?

## 📄 Documentation

- [x] Is there documentation for new IAM roles, policies, or automation logic ect?
- [x] Have runbooks or operational guides been updated?

## 📎 Related Issues / Tickets

_Reference any related issues, JIRA tickets, or documentation._

## ✅ Checklist

- [x] I have reviewed the code and confirm it meets the project’s IAM, security and automation standards.
- [x] I have verified that no sensitive data is exposed in logs or code.
- [x] I have updated relevant documentation and diagrams.
- [x] I have reviewed my own code and the plan

---

🛡️ **Security is everyone's responsibility. Please ensure all IAM changes are reviewed carefully.**

## ✅ Reviewer Checklist
- [ ] I have reviewed the code and confirm it meets the project’s IAM, security and automation standards.
- [ ] I have verified that no sensitive data is exposed in logs or code.
